### PR TITLE
[jit Python None should have its type inferred as NoneType

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15358,6 +15358,17 @@ a")
 
 
 class TestRecursiveScript(JitTestCase):
+    def test_inferred_nonetype(self):
+        class M(nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.x = None
+
+            def forward(self):
+                assert self.x is None
+
+        self.checkModule(M(), ())
+
     def test_init_error(self):
         class M(nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -840,10 +840,15 @@ bool Node::matches(
 }
 
 bool Node::mustBeNone() const {
-  return kind_ == prim::AutogradZero ||
+  // We can statically deduce this Node has returning None if:
+  return
+      // It's an AutogradZero node, or ...
+      kind_ == prim::AutogradZero ||
+      // It has only one output and that output is NoneType, or ...
+      (outputs().size() == 1 && output()->type() == NoneType::get()) ||
+      // It's a constant optional with no value in the attributes.
       (kind_ == prim::Constant && !this->hasAttributes() &&
-       (output()->type()->cast<OptionalType>() ||
-        output()->type() == NoneType::get()));
+       output()->type()->cast<OptionalType>());
 }
 
 void Node::dump() const {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -123,7 +123,7 @@ inline InferredType tryToInferType(py::handle input) {
   }
 
   if (input.is(py::none())) {
-    return InferredType("Cannot infer type of a None value");
+    return InferredType(NoneType::get());
   }
 
   // Try basic types first


### PR DESCRIPTION
This is actually useful. For example: in batchnorm.py, all the tracked
stats are either `nn.Parameter` or `None`. We should register them as
params if they are set, or attributes with type NoneType if they are
not.

ghstack-source-id: 2b3bb672b84edcf8e8dd2664e34d69d8f4c49747
Pull Request resolved: https://github.com/pytorch/pytorch/pull/26665

